### PR TITLE
Fixed the repository list not showing correctly all the repos

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
+++ b/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubSCMSource.java
@@ -1914,7 +1914,7 @@ public class GitHubSCMSource extends AbstractGitSCMSource {
                         }
                         if (myself != null && repoOwner.equalsIgnoreCase(myself.getLogin())) {
                             Set<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-                            for (GHRepository repo : myself.listRepositories(100, GHMyself.RepositoryListFilter.OWNER)) {
+                            for (GHRepository repo : myself.listRepositories(100, GHMyself.RepositoryListFilter.ALL)) {
                                 result.add(repo.getName());
                             }
                             return nameAndValueModel(result);


### PR DESCRIPTION
When you load the list of repositories (<select>) it currently shows only "Public and private repositories owned by current user", when you really want "All public and private repositories that current user has access or collaborates to" (https://github.com/kohsuke/github-api/blob/master/src/main/java/org/kohsuke/github/GHMyself.java#L23).

Right now it won't show the private repos where you are collaborator. It would still work if you manually change the select value using the browser's element inspector, so it is just a visual bug. The problem is that every time you change a setting you must do this again or itwill change the selected repo with the first one on the list.

Just changing the RepositoryListFilter value to ALL will correct this and show "All public and private repositories that current user has access or collaborates to".